### PR TITLE
Empty table behaviour

### DIFF
--- a/src/Keboola/DbExtractor/Extractor/Extractor.php
+++ b/src/Keboola/DbExtractor/Extractor/Extractor.php
@@ -187,12 +187,11 @@ abstract class Extractor
              throw new ApplicationException("Write to CSV failed: " . $e->getMessage(), 0, $e);
         }
 
-        if ($result['rows'] > 0) {
-            $this->createManifest($table);
-        } else {
+        $this->createManifest($table);
+        if ($result['rows'] === 0) {
             $this->logger->warn(
                 sprintf(
-                    "Query returned empty result. Nothing was imported for table [%s]",
+                    "Table [%s] returned an empty result set.",
                     $table['name']
                 )
             );
@@ -290,7 +289,12 @@ abstract class Extractor
             $output['rows'] = $numRows;
             return $output;
         }
-        // no rows found.  If incremental fetching is turned on, we need to preserve the last state
+        // no rows found.
+        // touch the output csv if headerless
+        if (!$includeHeader) {
+            $csv->writeRow([]);
+        }
+        // If incremental fetching is turned on, we need to preserve the last state
         if ($this->incrementalFetching['column'] && isset($this->state['lastFetchedRow'])) {
             $output = $this->state;
         }

--- a/tests/CommonExtractorTest.php
+++ b/tests/CommonExtractorTest.php
@@ -126,7 +126,7 @@ class CommonExtractorTest extends ExtractorTest
             file_get_contents($this->dataDir . '/out/tables/' . $result['imported'][0]['outputTable'] . ".csv.manifest"),
             true
         );
-        $this->assertArrayNotHasKey('columns', $manifest);
+        $this->assertArrayHasKey('columns', $manifest);
         $this->assertArrayNotHasKey('primary_key', $manifest);
         
         $this->assertExtractedData($this->dataDir . '/simple.csv', $result['imported'][1]['outputTable']);

--- a/tests/CommonExtractorTest.php
+++ b/tests/CommonExtractorTest.php
@@ -243,6 +243,8 @@ class CommonExtractorTest extends ExtractorTest
     {
         $outputCsvFile = $this->dataDir . '/out/tables/in.c-main.escaping.csv';
         $outputManifestFile = $this->dataDir . '/out/tables/in.c-main.escaping.csv.manifest';
+        @unlink($outputCsvFile);
+        @unlink($outputManifestFile);
 
         $config = $this->getConfig(self::DRIVER);
         $config['parameters']['tables'][0]['query'] = "SELECT * FROM escaping WHERE col1 = '123'";
@@ -250,8 +252,31 @@ class CommonExtractorTest extends ExtractorTest
         $result = ($this->getApp($config))->run();
 
         $this->assertEquals('success', $result['status']);
-        $this->assertFileNotExists($outputCsvFile);
-        $this->assertFileNotExists($outputManifestFile);
+        // It should create an empty csv and a manifest
+        $this->assertFileExists($outputCsvFile);
+        $this->assertFileExists($outputManifestFile);
+    }
+
+    public function testRunEmptyTable(): void
+    {
+        $outputCsvFile = $this->dataDir . '/out/tables/in.c-main.escaping.csv';
+        $outputManifestFile = $this->dataDir . '/out/tables/in.c-main.escaping.csv.manifest';
+        @unlink($outputCsvFile);
+        @unlink($outputManifestFile);
+
+        $config = $this->getConfig(self::DRIVER);
+        $this->db->exec("TRUNCATE TABLE `escaping`;");
+        unset($config['parameters']['tables'][0]['query']);
+        $config['parameters']['tables'][0]['table'] = [
+          "tableName" => "escaping",
+          "schema" => "testdb",
+        ];
+        $result = ($this->getApp($config))->run();
+
+        $this->assertEquals('success', $result['status']);
+        // It should create an empty csv and a manifest
+        $this->assertFileExists($outputCsvFile);
+        $this->assertFileExists($outputManifestFile);
     }
 
     public function testTestConnection(): void


### PR DESCRIPTION
fixes #60 

proposed changes:

- always output a manifest
- write empty csv if for empty result set 