### PR TITLE
Retry on ErrorException in outer proxy

### DIFF
--- a/src/Keboola/DbExtractor/Extractor/Extractor.php
+++ b/src/Keboola/DbExtractor/Extractor/Extractor.php
@@ -177,7 +177,7 @@ abstract class Extractor
             $this->logger,
             $maxTries,
             RetryProxy::DEFAULT_BACKOFF_INTERVAL,
-            ['Keboola\DbExtractor\Exception\DeadConnectionException']
+            ['Keboola\DbExtractor\Exception\DeadConnectionException', 'ErrorException']
         );
         try {
             $result = $proxy->call(function () use ($query, $maxTries, $outputTable, $isAdvancedQuery) {

--- a/src/Keboola/DbExtractor/Extractor/Extractor.php
+++ b/src/Keboola/DbExtractor/Extractor/Extractor.php
@@ -177,7 +177,7 @@ abstract class Extractor
             $this->logger,
             $maxTries,
             RetryProxy::DEFAULT_BACKOFF_INTERVAL,
-            ['Keboola\DbExtractor\Exception\DeadConnectionException', 'ErrorException']
+            [DeadConnectionException::class, \ErrorException::class]
         );
         try {
             $result = $proxy->call(function () use ($query, $maxTries, $outputTable, $isAdvancedQuery) {


### PR DESCRIPTION
In the tests the statement fetching doesn't throw an error exception when the connection dies, but it does on production, this will ensure those cases get retried.