### PR TITLE
Fixed key problem

### DIFF
--- a/generate-ssh-keys.sh
+++ b/generate-ssh-keys.sh
@@ -7,7 +7,7 @@ PUBLIC_KEY_FILE="/tmp/ssh.key.pub"
 rm -f ${PRIVATE_KEY_FILE}
 rm -f ${PUBLIC_KEY_FILE}
 
-ssh-keygen -b 4096 -t rsa -f ${PRIVATE_KEY_FILE} -q -N '' && echo "Done"
+ssh-keygen -b 4096 -m PEM -t rsa -f ${PRIVATE_KEY_FILE} -q -N '' && echo "Done"
 
 export SSH_KEY_PRIVATE=$(cat ${PRIVATE_KEY_FILE}) && echo "Private key exported to SSH_KEY_PRIVATE"
 


### PR DESCRIPTION
Based on the ssh-keygen version of the host (travis/windows/osx) PEM may not be the default format, but rather "new" OPENSSH format with different header (and other things), that does not play well with ssh/openssl in the image. 

The new format looks like this:
```
root@097f402f77d0:/code# cat /tmp/ssh-key-yEn3Kf
-----BEGIN OPENSSH PRIVATE KEY-----
b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAACFwAAAAdzc2gtcn
NhAAAAAwEAAQAAAgEApNGGWrEUON4NVioZ3bqb02twUAfgU86yFa/vzYBy8I2Iav9hIvC2
Fn3SgPKAhOof1t7y/wPXyF5a4B2D3ZZ1nyGrRPs1VRuuw0oZx4nECkhtdvFzCqL+K2s8+J
....
TJmix1iVtvDF0AAAEBAMoDOlvBjUE4YjNkQnPrp6EwFsyr4OkDU/rg0FW2zKgSNuEOZSR3
nsVARQUeTitBktZsV5/XIwd7ayaj9ixwvyPtU91c/2PCJWxGYh/N/sfKG+1nHjcRwtcqLt
8ezOiFZdPhM0gAmXVeouKPoqVKDzkWxm/dFJ5EMKaLVcUTevvozzBleC7pVYwwl3dyS21N
g9CT1/KJnu0mCbGF3FhE5B16g53UUMu97IXILmEM+O3tpBIucw7XSb9sheWhGb/krCqbJE
TuRTJCJvhlT5+sKERLpOYJ9zOwakV3mqJSm3dVkybpc2+HCNiJ+W0Iux1Mx9xDl0glyVKC
T0mt3knKGwkAAAAQdG9tYXNmZWpmYXJAWDIyMAECAw==
-----END OPENSSH PRIVATE KEY-----
```