### PR TITLE
Update ssh-tunnel library to v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,15 +14,15 @@
     "ext-pdo": "*",
     "keboola/csv": "^1.1",
     "keboola/php-datatypes": "^4.0",
-    "pimple/pimple": "^3.0",
-    "monolog/monolog": "^1.17",
-    "symfony/config": "^3.0",
-    "symfony/yaml": "^3.0",
-    "keboola/ssh-tunnel": "^2.0",
     "keboola/php-utils": "^2.3",
+    "keboola/ssh-tunnel": "^3.0",
+    "monolog/monolog": "^1.17",
     "nette/utils": "^2.4",
-    "vkartaviy/retry": "^0.2",
-    "symfony/serializer": "^3.1"
+    "pimple/pimple": "^3.0",
+    "symfony/config": "^3.0",
+    "symfony/serializer": "^3.1",
+    "symfony/yaml": "^3.0",
+    "vkartaviy/retry": "^0.2"
   },
   "require-dev": {
     "aws/aws-sdk-php": "^3.67",


### PR DESCRIPTION
Fixes: #118 

Changes:

- Update ssh-tunnel lib to v3 (to have IPv4 forced)

Packages was reordered due to:

```json
{
    "sort-packages": true
  }

```