### PR TITLE
Fix missing difference between: incremental loading and inc. fetching

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "ext-pdo": "*",
     "keboola/common-exceptions": "^1.0",
     "keboola/csv": "^2.1",
-    "keboola/db-extractor-config": "^1.3.4",
+    "keboola/db-extractor-config": "^1.3.6",
     "keboola/db-extractor-ssh-tunnel": "^1.1",
     "keboola/db-extractor-table-format": "^3.0",
     "keboola/php-component": "^8.1",

--- a/src/Extractor/BaseExtractor.php
+++ b/src/Extractor/BaseExtractor.php
@@ -287,7 +287,7 @@ abstract class BaseExtractor
 
         $manifestData = [
             'destination' => $exportConfig->getOutputTable(),
-            'incremental' => $exportConfig->isIncrementalFetching(),
+            'incremental' => $exportConfig->isIncrementalLoading(),
         ];
 
         if ($exportConfig->hasPrimaryKey()) {


### PR DESCRIPTION
Changes:
- Solving: https://keboola.atlassian.net/browse/COM-261
- Fixed  bug, `incremental: true` in the old code meant `incrementalFetching` is on, ... but `incrementalFetching` should be on if `incrementalFetchingColumn` is set ... 
- `incremental: true` turns on [Incremental loading](https://developers.keboola.com/extend/generic-extractor/incremental/) not incremental fetching.
- These features are usually used together, but are independent.
- For example, `incremental loading` can be used with a custom query, but `incremental fetching` not.
- See PR in `db-extractor-config`: https://github.com/keboola/db-extractor-config/pull/13