### PR TITLE
Add refactored RetryTest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,10 +31,10 @@
   },
   "require-dev": {
     "php-parallel-lint/php-parallel-lint": "^1.2",
+    "ihsw/toxiproxy-php-client": "^2.0",
     "keboola/coding-standard": ">=9.0.0",
     "keboola/php-temp": "^2.0",
     "phpstan/phpstan": "^0.12.14",
-    "aws/aws-sdk-php": "^3.107",
     "symfony/debug": "^4.3"
   },
   "autoload": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     depends_on:
       - sshproxy
       - mysql
+      - toxiproxy
     volumes:
       - ssh-keys:/root/.ssh:ro
       - ./tests/phpunit/data/common/ssl:/ssl-cert
@@ -32,6 +33,11 @@ services:
     environment:
       - TARGETS=mysql:3306,sshproxy:22
       - TIMEOUT=60
+
+  toxiproxy:
+    image: shopify/toxiproxy
+    depends_on:
+      - mysql
 
   mysql:
     image: mysql:5.6

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,7 @@
 parameters:
     checkMissingIterableValueType: false
-    ignoreErrors: []
+    excludes_analyse:
+        - 'tests/phpunit/Fixtures/run.php'
+    ignoreErrors:
+        # Bad phpdoc in library
+        - '#\$toxicity of method Ihsw\\Toxiproxy\\Proxy::create\(\) expects string, float given#'

--- a/src/Extractor/BaseExtractor.php
+++ b/src/Extractor/BaseExtractor.php
@@ -42,7 +42,7 @@ abstract class BaseExtractor
         $this->logger = $logger;
         $this->parameters = $this->createSshTunnel($this->parameters);
         $this->databaseConfig = $this->createDatabaseConfig($parameters['db']);
-        $this->connect();
+        $this->createConnection($this->databaseConfig);
         $this->adapter = $this->createExportAdapter();
     }
 
@@ -125,15 +125,6 @@ abstract class BaseExtractor
             }
         }
         return $output;
-    }
-
-    protected function connect(): void
-    {
-        try {
-            $this->createConnection($this->databaseConfig);
-        } catch (Throwable $e) {
-            throw new UserException('Error connecting to DB: ' . $e->getMessage(), 0, $e);
-        }
     }
 
     protected function createManifest(ExportConfig $exportConfig): void

--- a/tests/phpunit/Fixtures/run.php
+++ b/tests/phpunit/Fixtures/run.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use Keboola\DbExtractor\Exception\UserException;
+use Keboola\Component\Logger;
+use Keboola\Component\JsonHelper;
+use Keboola\CommonExceptions\UserExceptionInterface;
+use \Keboola\DbExtractor\Application;
+
+require __DIR__ . '/../../../vendor/autoload.php';
+
+// Standard run.php for Common (example) db extractor,
+// used to test Common extractor in process
+
+$logger = new Logger();
+
+try {
+    $dataFolder = getenv('KBC_DATADIR') === false ? '/data/' : (string) getenv('KBC_DATADIR');
+    if (file_exists($dataFolder . '/config.json')) {
+        $config = JsonHelper::readFile($dataFolder . '/config.json');
+    } else {
+        throw new UserException('Configuration file not found.');
+    }
+
+    // get the state
+    $inputStateFile = $dataFolder . '/in/state.json';
+    if (file_exists($inputStateFile)) {
+        $inputState = JsonHelper::readFile($inputStateFile);
+    } else {
+        $inputState = [];
+    }
+
+    $config['parameters']['data_dir'] = $dataFolder;
+    $config['parameters']['extractor_class'] = 'Common';
+    $app = new Application($config, $logger, $inputState);
+    $result = $app->run();
+
+    if ($app['action'] !== 'run') {
+        // Print sync action result
+        echo JsonHelper::encode($result);
+    } else if (!empty($result['state'])) {
+        // Write state if present
+        $outputStateFile = $dataFolder . '/out/state.json';
+        JsonHelper::writeFile($outputStateFile, $result['state']);
+    }
+    $logger->log('info', 'Extractor finished successfully.');
+    exit(0);
+} catch (UserExceptionInterface $e) {
+    $logger->error($e->getMessage());
+    exit(1);
+} catch (\Throwable $e) {
+    $logger->critical(
+        get_class($e) . ':' . $e->getMessage(),
+        [
+            'errFile' => $e->getFile(),
+            'errLine' => $e->getLine(),
+            'errCode' => $e->getCode(),
+            'errTrace' => $e->getTraceAsString(),
+            'errPrevious' => $e->getPrevious() ? get_class($e->getPrevious()) : '',
+        ]
+    );
+    exit(2);
+}

--- a/tests/phpunit/RetryTest.php
+++ b/tests/phpunit/RetryTest.php
@@ -1,0 +1,245 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\DbExtractor\Tests;
+
+use Ihsw\Toxiproxy\Proxy;
+use Keboola\Temp\Temp;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+class RetryTest extends TestCase
+{
+    use ToxiproxyTrait;
+    use TestDataTrait;
+
+    protected const LARGE_TABLE_NAME = 'large_test_table';
+    protected const LARGE_TABLE_ROWS = 100000;
+
+    protected Temp $temp;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->temp = new Temp();
+        $this->initDatabase();
+        $this->initToxiproxy();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $this->temp->remove();
+        $this->clearAllToxiproxies();
+    }
+
+    /**
+     * - Network is DOWN
+     * - Extractor is started
+     * - Extractor failed, after 3x retries, when establishing a connection
+     */
+    public function testNetworkDown(): void
+    {
+        $proxy = $this->createToxiproxyToDb();
+
+        // Network is down
+        $this->simulateNetworkDown($proxy);
+
+        // Extractor process is started
+        $process = $this->createProcess($proxy);
+        $process->start();
+
+        // Extractor process ended, network is still down
+        $process->wait();
+
+        // Connect is retried 3x and then extraction failed
+        // See DbConnection::CONNECT_MAX_RETRIES
+        $output = $process->getOutput();
+        $errorOutput = $process->getErrorOutput();
+        Assert::assertFalse($process->isSuccessful());
+        Assert::assertSame(1, $process->getExitCode());
+        Assert::assertStringContainsString('MySQL server has gone away. Retrying... [1x]', $output);
+        Assert::assertStringContainsString('MySQL server has gone away. Retrying... [2x]', $output);
+        Assert::assertStringContainsString('Error connecting to DB:', $errorOutput);
+        Assert::assertStringContainsString('MySQL server has gone away', $errorOutput);
+    }
+
+    /**
+     * - Network is DOWN
+     * - Extractor is started
+     * - After 2 seconds is network connection restored, network is UP
+     * - Extractor is successful, the logs shows that the retry was used
+     */
+    public function testNetworkDownUpDuringRetry(): void
+    {
+        $this->createLargeTable(self::LARGE_TABLE_ROWS, self::LARGE_TABLE_NAME);
+        $proxy = $this->createToxiproxyToDb();
+
+        // Network is down
+        $toxic = $this->simulateNetworkDown($proxy);
+
+        // Extractor process is started
+        $process = $this->createProcess($proxy);
+        $process->start();
+
+        // Network is up - 2 seconds after the process started
+        sleep(2);
+        $proxy->delete($toxic);
+
+        // Extractor process ended, network is up
+        // It should be successful, because retry mechanism
+        $process->wait();
+
+        // Process is successful
+        $output = $process->getOutput();
+        $errorOutput = $process->getErrorOutput();
+        Assert::assertTrue($process->isSuccessful());
+        Assert::assertSame(0, $process->getExitCode());
+
+        // Connect is successfully retried
+        Assert::assertStringContainsString('MySQL server has gone away. Retrying... [1x]', $output);
+        Assert::assertStringNotContainsString('Error connecting to DB:', $errorOutput); // not
+
+        // Extraction is successful
+        $this->assertOutputCsvValid();
+    }
+
+    /**
+     * - Network is UP
+     * - Extractor is started
+     * - After 1MB of transmitted data is network DOWN
+     * - Extractor failed, after 5x retries
+     */
+    public function testNetworkDownAfterLimit(): void
+    {
+        $this->createLargeTable(self::LARGE_TABLE_ROWS, self::LARGE_TABLE_NAME);
+        $proxy = $this->createToxiproxyToDb();
+
+        // Network will be down when transmitted data exceeded limit
+        $bytes = 1 * 1024 * 1024; // 1MB
+        $this->simulateNetworkLimitDataThenDown($proxy, $bytes);
+
+        // Extractor process is started
+        $process = $this->createProcess($proxy);
+        $process->start();
+
+        // Extractor process ended, network is still down
+        $process->wait();
+
+        // Query is retried 5x and then extraction failed
+        // See DbConnection::DEFAULT_MAX_RETRIES
+        $output = $process->getOutput();
+        $errorOutput = $process->getErrorOutput();
+        Assert::assertFalse($process->isSuccessful());
+        Assert::assertSame(1, $process->getExitCode());
+        Assert::assertStringContainsString('Empty row packet body', $output);
+        Assert::assertStringContainsString('Retrying... [1x]', $output);
+        Assert::assertStringContainsString('Retrying... [2x]', $output);
+        Assert::assertStringContainsString('Retrying... [3x]', $output);
+        Assert::assertStringContainsString('Retrying... [4x]', $output);
+        Assert::assertStringContainsString('DB query failed:', $errorOutput);
+        Assert::assertStringContainsString('Empty row packet body Tried 5 times.', $errorOutput);
+    }
+
+    /**
+     * - Network is UP
+     * - Extractor is started
+     * - After 1MB of transmitted data is network DOWN
+     * - After second retry is network connection restored, network is UP
+     * - Extractor is successful, the logs shows that the retry was used
+     */
+    public function testNetworkDownAfterLimitUpDuringRetry(): void
+    {
+        $this->createLargeTable(self::LARGE_TABLE_ROWS, self::LARGE_TABLE_NAME);
+        $proxy = $this->createToxiproxyToDb();
+
+        // Network will be down when transmitted data exceeded limit
+        $bytes = 1 * 1024 * 1024; // 1MB
+        $toxic = $this->simulateNetworkLimitDataThenDown($proxy, $bytes);
+
+        // Extractor process is started
+        $process = $this->createProcess($proxy);
+        $process->start(function (string $dest, string $msg) use ($proxy, $toxic): void {
+            // After second retry is network connection restored
+            if ($dest === 'out' && strpos($msg, 'Retrying... [2x]') !== false) {
+                $proxy->delete($toxic);
+            }
+        });
+
+        // Extractor process ended, network is up
+        // It should be successful, because retry mechanism
+        $process->wait();
+
+        // Process is successful
+        $output = $process->getOutput();
+        $errorOutput = $process->getErrorOutput();
+        Assert::assertTrue($process->isSuccessful());
+        Assert::assertSame(0, $process->getExitCode());
+
+        // Query is successfully retried
+        $output = $process->getOutput();
+        $errorOutput = $process->getErrorOutput();
+        Assert::assertTrue($process->isSuccessful());
+        Assert::assertSame(0, $process->getExitCode());
+        Assert::assertStringContainsString('Empty row packet body', $output);
+        Assert::assertStringContainsString('Retrying... [1x]', $output);
+        Assert::assertStringContainsString('Retrying... [2x]', $output);
+        Assert::assertStringNotContainsString('DB query failed:', $errorOutput); // not
+        Assert::assertStringContainsString('Extractor finished successfully.', $output);
+        Assert::assertSame('', $errorOutput);
+
+        // Extraction is successful
+        $this->assertOutputCsvValid();
+    }
+
+    private function createProcess(Proxy $proxy): Process
+    {
+        // Create config file
+        file_put_contents(
+            $this->temp->getTmpFolder() . '/config.json',
+            json_encode($this->createConfig($proxy))
+        );
+
+        // We run the extractor in a asynchronous process
+        // so we can change the network parameters via Toxiproxy.
+        return Process::fromShellCommandline(
+            'php ' . __DIR__ . '/Fixtures/run.php',
+            null,
+            ['KBC_DATADIR' => $this->temp->getTmpFolder()]
+        );
+    }
+
+    private function createConfig(Proxy $proxy): array
+    {
+        return [
+            'parameters' => [
+                'db' => [
+                    'host' => $this->getToxiproxyHost(),
+                    'port' => $proxy->getListenPort(),
+                    'database' => (string) getEnv('COMMON_DB_DATABASE'),
+                    'user' => (string) getEnv('COMMON_DB_USER'),
+                    '#password' => (string) getEnv('COMMON_DB_PASSWORD'),
+                ],
+                'id' => 123,
+                'name' => 'row_name',
+                'table' => [
+                    'tableName' => self::LARGE_TABLE_NAME,
+                    'schema' => (string) getEnv('COMMON_DB_DATABASE'),
+                ],
+                'outputTable' => 'output',
+            ],
+        ];
+    }
+
+    private function assertOutputCsvValid(): void
+    {
+        $csvFile = $this->temp->getTmpFolder() . '/out/tables/output.csv';
+        Assert::assertFileExists($csvFile);
+        Assert::assertSame(
+            self::LARGE_TABLE_ROWS . ' ' .$csvFile . "\n",
+            Process::fromShellCommandline('wc -l ' . escapeshellarg($csvFile))->mustRun()->getOutput()
+        );
+    }
+}

--- a/tests/phpunit/TestDataTrait.php
+++ b/tests/phpunit/TestDataTrait.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\DbExtractor\Tests;
+
+use PDO;
+use Keboola\Csv\CsvWriter;
+use Keboola\Temp\Temp;
+use Keboola\DbExtractor\Test\DataLoader;
+use Symfony\Component\Process\Process;
+
+trait TestDataTrait
+{
+    protected PDO $db;
+
+    protected Temp $temp;
+
+    protected function closeSshTunnels(): void
+    {
+        # Close SSH tunnel if created
+        $process = new Process(['sh', '-c', 'pgrep ssh | xargs -r kill']);
+        $process->mustRun();
+    }
+
+    protected function initDatabase(): void
+    {
+        $dataLoader = $this->createDataLoader();
+        $dataLoader->getPdo()->exec(
+            sprintf(
+                'DROP DATABASE IF EXISTS `%s`',
+                (string) getEnv('COMMON_DB_DATABASE')
+            )
+        );
+        $dataLoader->getPdo()->exec(
+            sprintf(
+                '
+                    CREATE DATABASE `%s`
+                    DEFAULT CHARACTER SET utf8
+                    DEFAULT COLLATE utf8_general_ci
+                ',
+                (string) getEnv('COMMON_DB_DATABASE')
+            )
+        );
+
+        $dataLoader->getPdo()->exec('USE ' . (string) getEnv('COMMON_DB_DATABASE'));
+
+        $dataLoader->getPdo()->exec('SET NAMES utf8;');
+        $dataLoader->getPdo()->exec(
+            'CREATE TABLE escapingPK (
+                                    col1 VARCHAR(155),
+                                    col2 VARCHAR(155),
+                                    PRIMARY KEY (col1, col2))'
+        );
+
+        $dataLoader->getPdo()->exec(
+            "CREATE TABLE escaping (
+                                  col1 VARCHAR(155) NOT NULL DEFAULT 'abc',
+                                  col2 VARCHAR(155) NOT NULL DEFAULT 'abc',
+                                  FOREIGN KEY (col1, col2) REFERENCES escapingPK(col1, col2))"
+        );
+
+        $dataLoader->getPdo()->exec(
+            "CREATE TABLE simple (
+                                  `_weird-I-d` VARCHAR(155) NOT NULL DEFAULT 'abc',
+                                  `SãoPaulo` VARCHAR(155) NOT NULL DEFAULT 'abc',
+                                  PRIMARY KEY (`_weird-I-d`))"
+        );
+
+        $inputFile = __DIR__ . '/data' . '/escaping.csv';
+        $simpleFile = __DIR__ . '/data' . '/simple.csv';
+        $dataLoader->load($inputFile, 'escapingPK');
+        $dataLoader->load($inputFile, 'escaping');
+        $dataLoader->load($simpleFile, 'simple', 0);
+
+        // let other methods use the db connection
+        $this->db = $dataLoader->getPdo();
+    }
+
+    protected function createLargeTable(int $rowCount = 5000000, string $tableName = 'large_test_table'): void
+    {
+        // Create CSV file with data
+        $csvFileName = $this->temp->getTmpFolder() . '/' . $tableName . '.csv';
+        $csv = new CsvWriter($csvFileName);
+        $header = ['uuid', 'name', 'number', 'text'];
+        $csv->writeRow($header);
+        for ($i = 0; $i < $rowCount; $i++) {
+            $csv->writeRow(
+                [uniqid('g'), 'The Lakes', '1', 'RbaXcGgFJ9mox3wLBcM88g7mQ3QGCuA4fe2oPAPD']
+            );
+        }
+
+        // Create table
+        $dataLoader = $this->createDataLoader();
+        $dataLoader->getPdo()->exec(sprintf(
+            'CREATE TABLE %s (`uuid` VARCHAR(255) NOT NULL, `name` VARCHAR(255), `int` INT, `uuid2` VARCHAR(255));',
+            $tableName
+        ));
+
+        // Load data to table
+        $dataLoader->load($csvFileName, $tableName, 1);
+        unlink($csvFileName);
+    }
+
+    protected function createDataLoader(): DataLoader
+    {
+        return new DataLoader(
+            (string) getEnv('COMMON_DB_HOST'),
+            (string) getEnv('COMMON_DB_PORT'),
+            (string) getEnv('COMMON_DB_DATABASE'),
+            (string) getEnv('COMMON_DB_USER'),
+            (string) getEnv('COMMON_DB_PASSWORD')
+        );
+    }
+}

--- a/tests/phpunit/ToxiproxyTrait.php
+++ b/tests/phpunit/ToxiproxyTrait.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\DbExtractor\Tests;
+
+use Ihsw\Toxiproxy\Proxy;
+use Ihsw\Toxiproxy\StreamDirections;
+use Ihsw\Toxiproxy\Toxic;
+use Ihsw\Toxiproxy\ToxicTypes;
+use Ihsw\Toxiproxy\Toxiproxy;
+
+trait ToxiproxyTrait
+{
+    protected Toxiproxy $toxiproxy;
+
+    protected function getToxiproxyHost(): string
+    {
+        return 'toxiproxy';
+    }
+
+    protected function initToxiproxy(): void
+    {
+        $this->toxiproxy = new Toxiproxy('http://' . $this->getToxiproxyHost() . ':8474');
+    }
+
+    protected function createToxiproxyToDb(): Proxy
+    {
+        return $this->toxiproxy->create('mysql_proxy', 'mysql:3306');
+    }
+
+    protected function clearAllToxiproxies(): void
+    {
+        foreach ($this->toxiproxy->getAll() as $proxy) {
+            $this->toxiproxy->delete($proxy);
+        }
+    }
+
+    protected function simulateNetworkDown(Proxy $proxy): Toxic
+    {
+        // https://github.com/Shopify/toxiproxy#timeout
+        return $proxy->create(ToxicTypes::TIMEOUT, StreamDirections::DOWNSTREAM, 1.0, [
+            'timeout' => 10,
+        ]);
+    }
+
+    protected function simulateNetworkLimitDataThenDown(Proxy $proxy, int $bytes): Toxic
+    {
+        // https://github.com/Shopify/toxiproxy#limit_data
+        return $proxy->create('limit_data', StreamDirections::DOWNSTREAM, 1.0, [
+            'bytes' => $bytes,
+        ]);
+    }
+}


### PR DESCRIPTION
Solving: https://keboola.atlassian.net/browse/COM-385
Slack: https://keboola.slack.com/archives/CQ1ASK06M/p1597306051029200?thread_ts=1597233995.016300&cid=CQ1ASK06M

Changes:
- Added `RetryTest` that uses `Toxiproxy`
- Fixed duplicate error msg prefix, when connection failed, eg. `Error connecting to DB: Error connecting to…`
    - There was duplicated code:
         - In this repo `db-extractor-common`: https://github.com/keboola/db-extractor-common/blob/68a8a5b4977f80e384c55c10478a2d92cd0ef188/src/Extractor/BaseExtractor.php#L135
         - And in `db-extractor-adapter`: https://github.com/keboola/db-extractor-adapter/blob/117ee22e25c8cbdcd80cf8f830b6966bd21a2017/src/Connection/BaseDbConnection.php#L111
         - The code is now only in the `db-extractor-adapter`