### PR TITLE
Add missing abstract method testConnection (accidentally removed)

### DIFF
--- a/src/Extractor/BaseExtractor.php
+++ b/src/Extractor/BaseExtractor.php
@@ -46,6 +46,8 @@ abstract class BaseExtractor
         $this->adapter = $this->createExportAdapter();
     }
 
+    abstract public function testConnection(): void;
+
     abstract protected function createConnection(DatabaseConfig $databaseConfig): void;
 
     abstract protected function createExportAdapter(): ExportAdapter;


### PR DESCRIPTION
Changes:
- Added accidentally removed method `BaseExtractor::testConnection`.
- ... it's implemented in `Common` class, so tests were working without this missing abstract method.