### PR TITLE
Disable connect retries for sync actions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "keboola/db-extractor-config": "^1.4",
     "keboola/db-extractor-ssh-tunnel": "^1.1",
     "keboola/db-extractor-table-format": "^3.0",
-    "keboola/db-extractor-adapter": "^1.0",
+    "keboola/db-extractor-adapter": "^1.0.3",
     "keboola/php-component": "^8.1",
     "keboola/php-datatypes": "^4.7",
     "keboola/php-utils": "^2.3||^3.0||^4.0",

--- a/src/Extractor/BaseExtractor.php
+++ b/src/Extractor/BaseExtractor.php
@@ -32,6 +32,8 @@ abstract class BaseExtractor
 
     protected ExportAdapter $adapter;
 
+    private bool $syncAction;
+
     private DatabaseConfig $databaseConfig;
 
     public function __construct(array $parameters, array $state, LoggerInterface $logger)
@@ -41,6 +43,8 @@ abstract class BaseExtractor
         $this->state = $state;
         $this->logger = $logger;
         $this->parameters = $this->createSshTunnel($this->parameters);
+        $this->syncAction = isset($this->parameters['action']) && $this->parameters['action'] !== 'run';
+
         $this->databaseConfig = $this->createDatabaseConfig($this->parameters['db']);
         $this->createConnection($this->databaseConfig);
         $this->adapter = $this->createExportAdapter();
@@ -210,5 +214,10 @@ abstract class BaseExtractor
     protected function createDatabaseConfig(array $data): DatabaseConfig
     {
         return DatabaseConfig::fromArray($data);
+    }
+
+    protected function isSyncAction(): bool
+    {
+        return $this->syncAction;
     }
 }

--- a/src/Extractor/Common.php
+++ b/src/Extractor/Common.php
@@ -89,6 +89,9 @@ class Common extends BaseExtractor
             $databaseConfig->getDatabase()
         );
 
+        // Disable connect retries for sync actions
+        $connectRetries = $this->isSyncAction() ? 1 : PdoConnection::CONNECT_DEFAULT_MAX_RETRIES;
+
         // Create connection
         $this->connection = new PdoConnection(
             $this->logger,
@@ -100,6 +103,7 @@ class Common extends BaseExtractor
                 $pdo->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, false);
                 $pdo->exec('SET NAMES utf8;');
             },
+            $connectRetries
         );
 
         // Check SSL


### PR DESCRIPTION
Changes:
- Added method `BaseExtractor::isSyncAction()`.
- Disabled connect retries for sync actions in `Common` extractor (example) + test.