### PR TITLE
setup logger in Application constructor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     unzip \
     libzip-dev \
+    zlib1g-dev \
+    libicu-dev \
     && rm -r /var/lib/apt/lists/* \
     && sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen \
     && locale-gen \
@@ -38,6 +40,9 @@ RUN pecl channel-update pecl.php.net \
     && pecl config-set php_ini /usr/local/etc/php.ini \
     && pecl install xdebug \
     && docker-php-ext-enable xdebug
+
+RUN docker-php-ext-configure intl \
+    && docker-php-ext-install intl
 
 
 ## Composer - deps always cached unless changed

--- a/src/Application.php
+++ b/src/Application.php
@@ -37,6 +37,8 @@ class Application extends Container
 
         $this['logger'] = $logger;
 
+        $this->setupLogger();
+
         $this->buildConfig($config);
 
         $this['extractor_factory'] = function () use ($app) {
@@ -51,19 +53,6 @@ class Application extends Container
 
     public function run(): array
     {
-        // Setup logger, copied from php-component/src/BaseComponent.php
-        // Will be removed in next refactoring steps,
-        // ... when Application will be replace by standard BaseComponent
-        if ($this['action'] !== 'run') { // $this->isSyncAction()
-            if ($this['logger'] instanceof SyncActionLogging) {
-                $this['logger']->setupSyncActionLogging();
-            }
-        } else {
-            if ($this['logger']instanceof AsyncActionLogging) {
-                $this['logger']->setupAsyncActionLogging();
-            }
-        }
-
         $actionMethod = $this['action'] . 'Action';
         if (!method_exists($this, $actionMethod)) {
             throw new UserException(sprintf('Action "%s" does not exist.', $this['action']));
@@ -169,5 +158,21 @@ class Application extends Container
             }
             throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
         });
+    }
+
+    private function setupLogger(): void
+    {
+        // Setup logger, copied from php-component/src/BaseComponent.php
+        // Will be removed in next refactoring steps,
+        // ... when Application will be replace by standard BaseComponent
+        if ($this['action'] !== 'run') { // $this->isSyncAction()
+            if ($this['logger'] instanceof SyncActionLogging) {
+                $this['logger']->setupSyncActionLogging();
+            }
+        } else {
+            if ($this['logger']instanceof AsyncActionLogging) {
+                $this['logger']->setupAsyncActionLogging();
+            }
+        }
     }
 }

--- a/src/Extractor/Common.php
+++ b/src/Extractor/Common.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Keboola\DbExtractor\Extractor;
 
 use Keboola\DbExtractor\Adapter\Query\DefaultQueryFactory;
+use Keboola\DbExtractor\Adapter\ResultWriter\DefaultResultWriter;
 use PDO;
 use Psr\Log\LoggerInterface;
 use Keboola\Temp\Temp;
@@ -40,10 +41,12 @@ class Common extends BaseExtractor
     protected function createExportAdapter(): ExportAdapter
     {
         $simpleQueryFactory = new DefaultQueryFactory($this->state);
+        $defaultResultWriter = new DefaultResultWriter($this->state);
         return new PdoExportAdapter(
             $this->logger,
             $this->connection,
             $simpleQueryFactory,
+            $defaultResultWriter,
             $this->dataDir,
             $this->state
         );

--- a/tests/phpunit/CommonExtractorTest.php
+++ b/tests/phpunit/CommonExtractorTest.php
@@ -1022,7 +1022,7 @@ class CommonExtractorTest extends ExtractorTest
         $config['parameters']['table'] = ['tableName' => 'sales'];
 
         $this->expectException(ConfigUserException::class);
-        $this->expectExceptionMessage('The child node "schema" at path "root.parameters.table" must be configured.');
+        $this->expectExceptionMessage('The child config "schema" under "root.parameters.table" must be configured.');
         $app = $this->getApp($config);
         $app->run();
     }


### PR DESCRIPTION
Je to kvůli testům, kde když nebyl logger nasetupovaný, tak se vypisoval defaultní log, např:
`[2021-01-07T10:13:24.298159+00:00] php-component.ERROR: ..... `