### PR TITLE
Generate correct base types and backend specific types when custom queries

### DIFF
--- a/src/Extractor/BaseExtractor.php
+++ b/src/Extractor/BaseExtractor.php
@@ -99,6 +99,7 @@ abstract class BaseExtractor
         return new DefaultManifestGenerator(
             $this->getMetadataProvider(),
             new DefaultManifestSerializer(),
+            $this->parameters['extractor_class'],
         );
     }
 

--- a/src/ExtractorFactory.php
+++ b/src/ExtractorFactory.php
@@ -28,6 +28,12 @@ class ExtractorFactory
             throw new UserException(sprintf("Extractor class '%s' doesn't exist", $extractorClass));
         }
 
-        return new $extractorClass($this->parameters, $this->state, $logger, $action, $datatypeSupport);
+        return new $extractorClass(
+            $this->parameters,
+            $this->state,
+            $logger,
+            $action,
+            $datatypeSupport,
+        );
     }
 }

--- a/tests/phpunit/DefaultManifestGeneratorTest.php
+++ b/tests/phpunit/DefaultManifestGeneratorTest.php
@@ -189,6 +189,9 @@ class DefaultManifestGeneratorTest extends TestCase
                     'name' => 'pk1',
                     'data_type' => [
                         'base' => [
+                            'type' => 'INTEGER',
+                        ],
+                        'snowflake' => [
                             'type' => 'integer',
                         ],
                     ],
@@ -204,6 +207,9 @@ class DefaultManifestGeneratorTest extends TestCase
                     'name' => 'pk2',
                     'data_type' => [
                         'base' => [
+                            'type' => 'INTEGER',
+                        ],
+                        'snowflake' => [
                             'type' => 'integer',
                         ],
                     ],
@@ -219,6 +225,9 @@ class DefaultManifestGeneratorTest extends TestCase
                     'name' => 'generated_col',
                     'data_type' => [
                         'base' => [
+                            'type' => 'STRING',
+                        ],
+                        'snowflake' => [
                             'type' => 'string',
                         ],
                     ],
@@ -333,6 +342,6 @@ class DefaultManifestGeneratorTest extends TestCase
         $metadataProvider->method('getTable')->willReturn($tableBuilder->build());
 
         $manifestSerializer = new DefaultManifestSerializer();
-        return new DefaultManifestGenerator($metadataProvider, $manifestSerializer);
+        return new DefaultManifestGenerator($metadataProvider, $manifestSerializer, 'Snowflake');
     }
 }


### PR DESCRIPTION
@ondrajodas takhle by to už mělo být OK, ale zjistil jsem, že když tam pak mám třeba length dvakrát (jednou u snowflake a jednou u base), tak v legacy formátu manifestu je to pak duplicitně. Přidal jsem teda ještě deduplikci tu https://github.com/keboola/php-component/pull/87. Pak už to je v tom snowflake extractoru všechno správně