### PR TITLE
fix: Remove length ONLY for base types

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16,7 +16,7 @@ parameters:
 			path: src/ExtractorFactory.php
 
 		-
-			message: "#^Parameter \\#2 \\$dataTypes of class Keboola\\\\Component\\\\Manifest\\\\ManifestManager\\\\Options\\\\OutTable\\\\ManifestOptionsSchema constructor expects array\\<string, array\\{type\\: string, length\\?\\: string, default\\?\\: string\\}\\>\\|null, non\\-empty\\-array\\<non\\-falsy\\-string, array\\{type\\?\\: mixed, default\\?\\: mixed\\}\\> given\\.$#"
+			message: "#^Parameter \\#2 \\$dataTypes of class Keboola\\\\Component\\\\Manifest\\\\ManifestManager\\\\Options\\\\OutTable\\\\ManifestOptionsSchema constructor expects array\\<string, array\\{type\\: string, length\\?\\: string, default\\?\\: string\\}\\>\\|null, non\\-empty\\-array\\<non\\-falsy\\-string, array\\{type\\?\\: mixed, default\\?\\: mixed, length\\?\\: mixed\\}\\> given\\.$#"
 			count: 1
 			path: src/Manifest/DefaultManifestGenerator.php
 

--- a/src/Manifest/DefaultManifestGenerator.php
+++ b/src/Manifest/DefaultManifestGenerator.php
@@ -129,6 +129,9 @@ class DefaultManifestGenerator implements ManifestGenerator
             if (isset($columnMetadata[Common::KBC_METADATA_KEY_TYPE])) {
                 $baseType['type'] = $columnMetadata[Common::KBC_METADATA_KEY_TYPE];
             }
+            if (isset($columnMetadata[Common::KBC_METADATA_KEY_LENGTH])) {
+                $baseType['length'] = $columnMetadata[Common::KBC_METADATA_KEY_LENGTH];
+            }
             $dataTypes[$backend] = $baseType;
         }
 

--- a/tests/phpunit/DefaultManifestGeneratorTest.php
+++ b/tests/phpunit/DefaultManifestGeneratorTest.php
@@ -249,6 +249,7 @@ class DefaultManifestGeneratorTest extends TestCase
             $builder = ColumnBuilder::create();
             $builder->setName($name);
             $builder->setType($type);
+            $builder->setLength($type === 'integer' ? null : '255');
             $columnsMetadata[] = $builder->build();
         }
 
@@ -314,6 +315,7 @@ class DefaultManifestGeneratorTest extends TestCase
                             'type' => 'STRING',
                         ],
                         'snowflake' => [
+                            'length' => '255',
                             'type' => 'string',
                         ],
                     ],


### PR DESCRIPTION
Ještě jsem tam při odebírání té délky u base type omylem tu délku odstranil i nativních typů. Teď jsem si toho všiml u SNFK extraktoru 🤦‍♂️ Nebylo to pokryto v testech, tak jsem to tam přidal.