### PR TITLE
Do not propagate length to datatype definition class when is zero

### DIFF
--- a/src/Manifest/DefaultManifestGenerator.php
+++ b/src/Manifest/DefaultManifestGenerator.php
@@ -188,7 +188,7 @@ class DefaultManifestGenerator implements ManifestGenerator
         if (class_exists($dataTypeClass)) {
             try {
                 $options = [];
-                if ($column->hasLength()) {
+                if ($column->hasLength() && $column->getLength() !== '0') {
                     $options['length'] = $column->getLength();
                 }
                 /** @var \Keboola\Datatype\Definition\DefinitionInterface $backendDataTypeDefinition */


### PR DESCRIPTION
SNFLK z nějakého důvodu může dostat length 0 např. u VARCHARu. Pak to tady padne: https://app.datadoghq.eu/logs?query=%40exceptionId%3A%2A18d6f705df6bafc0c281a5f546699d34%2A%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AgAAAZDf3rjEIwSSfgAAAAAAAAAYAAAAAEFaRGYzc2ZyQUFDMkpPcDRDUGxwRmdBQgAAACQAAAAAMDE5MGRmZGUtZjFhYy00MWUzLWIzZGItNTY0ZWRhZTc2ZjNj&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1721742342072&to_ts=1721743242072&live=true