### PR TITLE
Generate base types for generic storage

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,8 +12,8 @@ jobs:
       - name: Build image
         run: |
           docker login --username "$DOCKERHUB_USER" --password "$DOCKERHUB_TOKEN"
-          docker-compose build
+          docker compose build
       - name: Run tests
         run: |
-          docker-compose run wait
-          docker-compose run tests composer ci
+          docker compose run wait
+          docker compose run tests composer ci

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Common classes for creating vendor specific database extractors.
 
 ## Development and running tests
 
-    docker-compose build
-    docker-compose run --rm tests  # runs the tests
+    docker compose build
+    docker compose run --rm tests  # runs the tests
 
 ## Usage
 Add the library to your component's composer:

--- a/src/Manifest/DefaultManifestGenerator.php
+++ b/src/Manifest/DefaultManifestGenerator.php
@@ -188,7 +188,7 @@ class DefaultManifestGenerator implements ManifestGenerator
         if (class_exists($dataTypeClass)) {
             try {
                 $options = [];
-                if ($column->hasLength()) {
+                if ($column->hasLength() && $column->getLength() !== '0') {
                     $options['length'] = $column->getLength();
                 }
                 /** @var \Keboola\Datatype\Definition\DefinitionInterface $backendDataTypeDefinition */

--- a/src/Manifest/DefaultManifestGenerator.php
+++ b/src/Manifest/DefaultManifestGenerator.php
@@ -8,6 +8,7 @@ use Keboola\Component\Manifest\ManifestManager\Options\OutTable\ManifestOptions;
 use Keboola\Component\Manifest\ManifestManager\Options\OutTable\ManifestOptionsSchema;
 use Keboola\Datatype\Definition\Common;
 use Keboola\Datatype\Definition\Exception\InvalidTypeException;
+use Keboola\Datatype\Definition\GenericStorage;
 use Keboola\DbExtractor\Adapter\Metadata\MetadataProvider;
 use Keboola\DbExtractor\Adapter\ValueObject\ExportResult;
 use Keboola\DbExtractor\Adapter\ValueObject\QueryMetadata;
@@ -185,26 +186,28 @@ class DefaultManifestGenerator implements ManifestGenerator
         $dataTypes = null;
 
         $dataTypeClass = sprintf('\\Keboola\\Datatype\\Definition\\%s', $this->extractorClass);
-        if (class_exists($dataTypeClass)) {
-            try {
-                $options = [];
-                if ($column->hasLength() && $column->getLength() !== '0') {
-                    $options['length'] = $column->getLength();
-                }
-                /** @var \Keboola\Datatype\Definition\DefinitionInterface $backendDataTypeDefinition */
-                $backendDataTypeDefinition = new $dataTypeClass($column->getType(), $options);
-                $baseType = $backendDataTypeDefinition->getBasetype();
-            } catch (InvalidTypeException) {
-                $baseType = 'string';
-            }
-            $baseTypeSchema = [
-                'type' => $baseType,
-                'default' => $column->hasDefault() ? (string) $column->getDefault() : null,
-            ];
-            $baseTypeSchema = array_filter($baseTypeSchema, fn($value) => $value !== null);
-
-            $dataTypes['base'] = $baseTypeSchema;
+        if (!class_exists($dataTypeClass)) {
+            $dataTypeClass = GenericStorage::class;
         }
+
+        try {
+            $options = [];
+            if ($column->hasLength()) {
+                $options['length'] = $column->getLength();
+            }
+            /** @var \Keboola\Datatype\Definition\DefinitionInterface $backendDataTypeDefinition */
+            $backendDataTypeDefinition = new $dataTypeClass($column->getType(), $options);
+            $baseType = $backendDataTypeDefinition->getBasetype();
+        } catch (InvalidTypeException) {
+            $baseType = 'string';
+        }
+        $baseTypeSchema = [
+            'type' => $baseType,
+            'default' => $column->hasDefault() ? (string) $column->getDefault() : null,
+        ];
+        $baseTypeSchema = array_filter($baseTypeSchema, fn($value) => $value !== null);
+
+        $dataTypes['base'] = $baseTypeSchema;
 
         $backend = strtolower($this->extractorClass);
         if (in_array($backend, ManifestOptionsSchema::ALLOWED_DATA_TYPES_BACKEND, true)) {


### PR DESCRIPTION
Failing test https://github.com/keboola/db-extractor-common/pull/195/commits/bfd63ec03d898269c0db8c5963d3bb12d20ba836 (negeneruje žádný base types pokud je backend PostgreSQL): https://github.com/keboola/db-extractor-common/actions/runs/10286235624/job/28466404146

Success job po úpravě (base types jsou vygenerovaný a správně resolvnutý [e.g. varchar = string]): https://github.com/keboola/db-extractor-common/actions/runs/10286379009

Po releasu bude potřeba updanout v ex-pgsql a případně pokud na to narazím i v nějakým jiným ex, ale není třeba updatovat naštěstí všude.