### PR TITLE
Fix min. required version of db-extractor-adapter to 1.15.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "ext-pdo": "*",
         "keboola/common-exceptions": "^1.1",
         "keboola/csv": "^3.2",
-        "keboola/db-extractor-adapter": "^1.15",
+        "keboola/db-extractor-adapter": "^1.15.1",
         "keboola/db-extractor-config": "^1.15",
         "keboola/db-extractor-ssh-tunnel": "^1.3.0",
         "keboola/db-extractor-table-format": "^3.8",


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PST-2318

Proper functionality of the SSH tunnel `RetryProxy` requires [version 1.15.1](https://github.com/keboola/db-extractor-adapter/releases/tag/1.15.1) of `db-extrator-adapter`